### PR TITLE
feat: ctrl+scroll to change editor font size

### DIFF
--- a/assets/js/explorerTree/tabHandler.js
+++ b/assets/js/explorerTree/tabHandler.js
@@ -26,6 +26,7 @@ import {
 import { BottomWindow, closeAllWindows } from "../handlers/BottomWindowHandler.js"
 import { initJSSH } from "../../../ace/plugins/languageSyntaxEnhance.js"
 import { enableSmoothScroll } from "../../plugins/aceSmoothScroller/index.js"
+import { Setting } from "../settings.js"
 import {
     setCurrentLanguage,
     setColumn,
@@ -748,6 +749,15 @@ export async function openTab(path, content, extension, name, pathContext, isNew
             enableSmoothScroll(editor)
         }
     }
+
+    editor.container.addEventListener('wheel', (e) => {
+        if (!e.ctrlKey && !e.metaKey) return
+        e.preventDefault()
+        e.stopPropagation()
+        const px = parseFloat(getComputedStyle(document.body).getPropertyValue('--editor-font-size'))
+        const next = Math.min(200, Math.max(50, Math.round(px / 15 * 100) + (e.deltaY < 0 ? 5 : -5)))
+        Setting.editorTextSize(next)
+    }, { passive: false, capture: true })
 
     const languageContextName = fileNameInfo != false ? `${fileNameInfo.name} (${fileNameInfo.mode.toUpperCase()})` : language.name
     setCurrentLanguage(languageContextName, { editor: editor })


### PR DESCRIPTION
Added wheel event listener with capture: true on the editor container. Intercepts Ctrl/Cmd + scroll before the smooth scroller and adjusts font size by ±5% via the existing Setting.editorTextSize.