### PR TITLE
feat: drag-and-drop tab reordering

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -775,6 +775,9 @@ body.explorer-resizing {
     cursor: pointer;
     color: var(--text-color);
 }
+.code-tab.dragging { opacity: 0.4; }
+.code-tab.drag-over-left { border-left: 2px solid var(--link-color); }
+.code-tab.drag-over-right { border-right: 2px solid var(--link-color); }
 .code-tab.active {
     border-bottom: 2px solid var(--link-color);
 }

--- a/assets/js/explorerTree/tabHandler.js
+++ b/assets/js/explorerTree/tabHandler.js
@@ -869,6 +869,37 @@ export async function openTab(path, content, extension, name, pathContext, isNew
         `;
     tabsBar.appendChild(tab);
 
+    tab.draggable = true
+
+    tab.addEventListener('dragstart', () => tab.classList.add('dragging'))
+
+    tab.addEventListener('dragend', () => {
+        tab.classList.remove('dragging')
+        tabsBar.querySelectorAll('.drag-over-left, .drag-over-right')
+            .forEach(t => t.classList.remove('drag-over-left', 'drag-over-right'))
+    })
+
+    tab.addEventListener('dragover', (e) => {
+        e.preventDefault()
+        const dragging = tabsBar.querySelector('.dragging')
+        if (!dragging || dragging === tab) return
+        tabsBar.querySelectorAll('.drag-over-left, .drag-over-right')
+            .forEach(t => t.classList.remove('drag-over-left', 'drag-over-right'))
+        const { left, width } = tab.getBoundingClientRect()
+        tab.classList.add(e.clientX < left + width / 2 ? 'drag-over-left' : 'drag-over-right')
+    })
+
+    tab.addEventListener('dragleave', () => tab.classList.remove('drag-over-left', 'drag-over-right'))
+
+    tab.addEventListener('drop', (e) => {
+        e.preventDefault()
+        const dragging = tabsBar.querySelector('.dragging')
+        if (!dragging || dragging === tab) return
+        const { left, width } = tab.getBoundingClientRect()
+        tabsBar.insertBefore(dragging, e.clientX < left + width / 2 ? tab : tab.nextSibling)
+        tab.classList.remove('drag-over-left', 'drag-over-right')
+    })
+
     // if tab is a new file (from dragNdrop or smth)
 
     if (isNew) {


### PR DESCRIPTION
Added native HTML5 drag events on each tab. Dragging shows opacity on the dragged tab and a blue indicator line on the target. Drops insert before/after based on cursor position.