### PR TITLE
fix(auth): correct setAttremoveAttributeribute typo in unDisableButtons

### DIFF
--- a/assets/js/auth/authRenderer.js
+++ b/assets/js/auth/authRenderer.js
@@ -64,7 +64,7 @@ export function unDisableButtons() {
     }
     if (emailInput) {
         emailInput.parentElement.removeAttribute("disabled", true)
-        emailInput.setAttremoveAttributeribute("disabled", true)
+        emailInput.removeAttribute("disabled", true)
     }
     if (codeInput) {
         codeInput.parentElement.removeAttribute("disabled", true)


### PR DESCRIPTION
Баг
В `assets/js/auth/authRenderer.js:67` вызывается
`emailInput.setAttremoveAttributeribute("disabled", true)`. Такого метода
не существует, поэтому `unDisableButtons()` бросает `TypeError` и завершается, оставляя поле email заблокированным после неуспешного входа.

Фикс
Я заменил на `emailInput.removeAttribute("disabled", true)` - соответствует
коду, использованному для остальных полей выше.

Проверка
Вручную воспроизведён сценарий неуспешного входа - поле email корректно разблокируется.

Fixes #31