### PR TITLE
fix(sandbox): import app from electron for createNativeImageFromUrl

### DIFF
--- a/app/sandbox/tools.js
+++ b/app/sandbox/tools.js
@@ -1,4 +1,4 @@
-const { net, nativeImage } = require("electron")
+const { net, nativeImage, app } = require("electron")
 const fs = require("fs")
 const path = require("path")
 


### PR DESCRIPTION
Баг
В `app/sandbox/tools.js:11` функция `createNativeImageFromUrl` вызывает
`await app.whenReady()`, но `app` не импортирован - в 1 строке указаны только `net` и `nativeImage`. Любой вызов функции
бросает `ReferenceError: app is not defined`, промис не выполняется,
картинка не загружается.

Фикс
Добавлен `app` в деструктуризацию импорта из `electron`:

​```js
const { net, nativeImage, app } = require("electron")
​```

Проверка
Локально воспроизведён сценарий: `ReferenceError` устранён, `whenReady()` корректно дожидается готовности, `net.request()` отрабатывает.

Fixes #33