### PR TITLE
fix(preview): resolve image and SVG opening, tab switching, and code flashing

### DIFF
--- a/assets/css/components/codeWrapper.css
+++ b/assets/css/components/codeWrapper.css
@@ -17,7 +17,8 @@
 }
 
 .code-wrapper .bottom-window__container.full {
-    height: -webkit-fill-available;
+    top: 42px;
+    height: calc(100% - 42px - 50px);
 }
 
 .code-wrapper .bottom-window {
@@ -36,6 +37,7 @@
     max-height: 100%;
     height: 100%;
     border-top: 0px;
+    transition: none;
 }
 
 .code-wrapper .bottom-window .bottom-window__content {
@@ -50,17 +52,35 @@
 
 .code-wrapper .bottom-window .bottom-window__content .image-preview {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     position: absolute;
     width: 100%;
-    height: calc(100% - 15%);
+    height: 100%;
+    overflow: hidden;
+    user-select: none;
+}
+
+.code-wrapper .bottom-window .bottom-window__content .image-preview-stage {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
 }
 
 .code-wrapper .bottom-window .bottom-window__content .image-preview img {
-    max-width: 800px;
-    max-height: 500px;
+    max-width: 80%;
+    max-height: 80%;
+    object-fit: contain;
+    transition: transform 0.05s ease-out;
+    user-select: none;
+    cursor: default;
 }
+
+
 
 .code-wrapper .bottom-window.console {
     overflow: hidden;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -746,6 +746,8 @@ body.explorer-resizing {
     height: 42px;
     background: var(--body-color);
     border-bottom: 1px solid var(--block-divider-border-color);
+    position: relative;
+    z-index: 20;
 }
 .code-tabs::-webkit-scrollbar {
     display: none;

--- a/assets/js/explorerTree/handlers/bindFileClicksHandler.js
+++ b/assets/js/explorerTree/handlers/bindFileClicksHandler.js
@@ -17,7 +17,8 @@ export function bindFileClicks({ scopeEl, tabsByPath, recentlyClosed, pathContex
             }
 
             const cached = recentlyClosed.get(filePath);
-            const content = cached ? cached.content : await window.electron.readFileContent(filePath);
+            const isBinaryImage = ["png", "jpg", "jpeg", "gif", "webp", "ico", "bmp"].includes(extension);
+            const content = cached ? cached.content : (isBinaryImage ? "" : await window.electron.readFileContent(filePath));
 
             openTab(filePath, content, extension, name, pathContext, false, settings);
         });

--- a/assets/js/explorerTree/tabHandler.js
+++ b/assets/js/explorerTree/tabHandler.js
@@ -26,6 +26,7 @@ import {
     EditorAdapter
 } from "../lib.js"
 import { BottomWindow, closeAllWindows } from "../handlers/BottomWindowHandler.js"
+import { bindImageZoomHandlers } from "../handlers/imageZoomHandler.js"
 import { enableSmoothScroll } from "../../plugins/aceSmoothScroller/index.js"
 import { Setting } from "../settings.js"
 import {
@@ -649,7 +650,10 @@ function initExtensionEditorAPIEvents({ editor }) {
 }
 
 export async function openTab(path, content, extension, name, pathContext, isNew = false, settings = {}) {
-    closeAllWindows()
+    let language = Languages.get(extension)
+    const isImage = language.name == "Image" || extension == "svg"
+
+    closeAllWindows(isImage ? "imagePreview" : null)
     setAppTitle(name)
 
     currentContent = content
@@ -663,16 +667,12 @@ export async function openTab(path, content, extension, name, pathContext, isNew
     pane.id = id;
     editorWrapper.appendChild(pane);
 
-    let language = Languages.get(extension)
-    let languageIcon = await Languages.getIconPath(extension)
-
     let fileNameInfo = Filenames.get(name)
-    let fileNameInfoIcon = await Filenames.getIconPath(name)
 
     const codeMirrorView = window.CodeMirror.create(
         document.getElementById(id),
         {
-            value: content
+            value: isImage ? "" : content
         }
     )
 
@@ -686,12 +686,8 @@ export async function openTab(path, content, extension, name, pathContext, isNew
     const imagePreviewWindow = new BottomWindow("imagePreview", { title: "Preview" })
     imagePreviewWindow.removeClose()
 
-    if (language.name == "Image") {
-        disableSave()
-        const escapedPath = escapeHtml(path);
-        imagePreviewWindow.set(`<div class="image-preview"><img src="${escapedPath}"></div>`)
-        imagePreviewWindow.fullscreen()
-        imagePreviewWindow.show()
+    if (isImage) {
+        renderImagePreview(imagePreviewWindow, path)
     }
     else {
         enableSave()
@@ -816,13 +812,13 @@ export async function openTab(path, content, extension, name, pathContext, isNew
     });
 
     if (cached) {
-        editor.setValue(cached.content ?? "", -1);
+        if (!isImage) editor.setValue(cached.content ?? "", -1);
         editor.resetUndoManager();
         setErrors(editor.getAnnotations())
         if (cached.cursor) editor.moveCursorTo(cached.cursor.row, cached.cursor.column);
         if (typeof cached.scrollTop === "number") editor.setScrollTop(cached.scrollTop);
     } else {
-        editor.setValue(content ?? "", -1);
+        if (!isImage) editor.setValue(content ?? "", -1);
         editor.resetUndoManager();
         setErrors(editor.getAnnotations())
     }
@@ -906,6 +902,7 @@ export async function openTab(path, content, extension, name, pathContext, isNew
         paneEl: pane,
         ErrorsHistoryWindow: ErrorsHistoryWindow,
         language: language,
+        isImage: isImage,
         new: isNew,
         fileName: name,
         color: language.color,
@@ -1061,6 +1058,11 @@ export function closeTab(path) {
 
     const stillHas = !!tabsBar.querySelector(".code-tab");
     if (!stillHas) {
+        const imagePreviewWindow = BottomWindow.get("imagePreview");
+        if (imagePreviewWindow) {
+            imagePreviewWindow.fullscreen(false);
+            imagePreviewWindow.hide();
+        }
         startScreen?.classList.remove("hidden");
         toggleCodeFooter(false)
         tabsBar.classList.add("hidden");
@@ -1084,6 +1086,21 @@ export async function reopenLastClosed() {
     const name = path.split(/[\\/]/).pop();
 
     openTab(path, state.content, extension, name, path, false, settings);
+}
+
+function renderImagePreview(imagePreviewWindow, realPath) {
+    disableSave();
+    const escapedPath = escapeHtml(realPath);
+    imagePreviewWindow.set(`
+        <div class="image-preview">
+            <div class="image-preview-stage">
+                <img src="${escapedPath}" alt="preview">
+            </div>
+        </div>
+    `);
+    imagePreviewWindow.fullscreen();
+    imagePreviewWindow.show();
+    bindImageZoomHandlers(imagePreviewWindow.winContent);
 }
 
 export function activateTab(tabEl) {
@@ -1126,6 +1143,15 @@ export function activateTab(tabEl) {
 
     if (rec && rec.language) {
         updateVisibleOnElements(ext, rec.language);
+    }
+
+    const imagePreviewWindow = BottomWindow.get("imagePreview") || new BottomWindow("imagePreview", { title: "Preview" });
+    if (rec.isImage) {
+        renderImagePreview(imagePreviewWindow, realPath);
+    } else {
+        enableSave();
+        imagePreviewWindow.fullscreen(false);
+        imagePreviewWindow.hide();
     }
 }
 

--- a/assets/js/handlers/BottomWindowHandler.js
+++ b/assets/js/handlers/BottomWindowHandler.js
@@ -277,7 +277,11 @@ export class BottomWindow {
     }
 }
 
-export function closeAllWindows() {
-    BottomWindow.windows.forEach(window => window.hide())
-    document.querySelector(".bottom-window__container").classList.remove("full")
+export function closeAllWindows(exceptId = null) {
+    BottomWindow.windows.forEach((window, id) => {
+        if (id !== exceptId) window.hide()
+    })
+    if (!exceptId) {
+        document.querySelector(".bottom-window__container").classList.remove("full")
+    }
 }

--- a/assets/js/handlers/imageZoomHandler.js
+++ b/assets/js/handlers/imageZoomHandler.js
@@ -1,0 +1,34 @@
+export function bindImageZoomHandlers(container) {
+    const previewEl = container.querySelector(".image-preview");
+    if (!previewEl) return;
+
+    const img = previewEl.querySelector("img");
+    if (!img) return;
+
+    let scale = 1;
+
+    function updateScale() {
+        img.style.transform = `scale(${scale})`;
+    }
+
+    const handleKeyDown = (e) => {
+        const isPreviewActive = document.querySelector(".bottom-window__container.full")?.contains(previewEl) && !previewEl.closest(".bottom-window.hidden");
+        if (isPreviewActive) {
+            if (e.key === "+" || e.key === "=") {
+                e.preventDefault();
+                scale = Math.min(scale * 1.25, 10);
+                updateScale();
+            } else if (e.key === "-" || e.key === "_") {
+                e.preventDefault();
+                scale = Math.max(scale * 0.8, 0.1);
+                updateScale();
+            } else if (e.key === "0") {
+                e.preventDefault();
+                scale = 1;
+                updateScale();
+            }
+        }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+}


### PR DESCRIPTION
### Changes
- Fix tab switching & preview window lifecycle for image and SVG files (`activateTab`, `closeTab`)
- Prevent SVG XML source code from flashing on initial load
- Optimize performance by skipping raw binary loading in CodeMirror
- Fix `.code-tabs` layering (`z-index: 20`) to keep tabs visible during fullscreen previews
- Add keyboard shortcuts for image zooming (`+`, `-`, `0`)