### PR TITLE
fix: upgrade tar to 7.5.19 (CVE-2026-59873)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "node-global-key-listener": "^0.3.0",
                 "node-gyp": "^12.4.0",
                 "oxc-parser": "^0.140.0",
+                "tar": "^7.5.19",
                 "ws": "^8.19.0"
             },
             "devDependencies": {
@@ -4794,9 +4795,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.19",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+            "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "node-global-key-listener": "^0.3.0",
         "node-gyp": "^12.4.0",
         "oxc-parser": "^0.140.0",
+        "tar": "^7.5.19",
         "ws": "^8.19.0"
     }
 }


### PR DESCRIPTION
## Summary
Upgrade tar from 7.5.16 to 7.5.19 to fix CVE-2026-59873.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-59873 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-59873` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: tar: node-tar: Denial of Service via crafted gzip bomb

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-59873` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
