### PR TITLE
fix: toggle maximize/unmaximize on window square button click

### DIFF
--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -185,7 +185,11 @@ async function createWindow() {
 
     ipcMain.on("fullscreen", () => {
         if (mainWindow) {
-            mainWindow.maximize();
+            if (mainWindow.isMaximized()) {
+                mainWindow.unmaximize();
+            } else {
+                mainWindow.maximize();
+            }
         }
     });
 


### PR DESCRIPTION
## Description

The maximize button in the title bar only maximized the window but never restored it when clicked again. This is inconsistent with standard desktop window behavior.

## Changes

- Added a check for `mainWindow.isMaximized()` in the fullscreen IPC handler
- Calls `mainWindow.unmaximize()` if already maximized, otherwise `mainWindow.maximize()` — making the button a proper toggle

## Testing

1. Launch the app
2. Click the maximize button — window should maximize
3. Click it again — window should restore to its previous size
