### PR TITLE
feat(explorer): add collapse all button

### DIFF
--- a/app/renderer.js
+++ b/app/renderer.js
@@ -28,6 +28,7 @@ import { initActions } from "../assets/js/actions.js"
 
 import { handleHistoryTab } from "../assets/js/explorerTabsHandlers/history.js"
 import { handleBugsTab } from "../assets/js/explorerTabsHandlers/bugs.js"
+import { getFolderIconUrl } from "../assets/js/iconRegistry.js"
 import { electronAPI, getDirname, readSettings } from "../assets/js/global.js"
 import { closeAllTabs } from "../assets/js/explorerTree/tabHandler.js"
 
@@ -198,9 +199,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (localData.nonAccountMode) {
         loader?.classList.add("hidden");
 
-        yourOrganizationsPopupItem.classList.add("disabled")
-        logoutPopupItem.classList.add("disabled")
-        createOrgPopupItem.classList.add("disabled")
+        yourOrganizationsPopupItem?.classList.add("disabled")
+        logoutPopupItem?.classList.add("disabled")
+        createOrgPopupItem?.classList.add("disabled")
 
         topbarCenterUserData.querySelector("#username").textContent = gls.get("notAuth")
         topbarCenterUserData.querySelector("#current_hours").classList.add("v-hidden")
@@ -438,6 +439,22 @@ document.addEventListener("DOMContentLoaded", async () => {
     document.querySelectorAll("#close_folder").forEach(btn => {
         btn.addEventListener("click", () => {
             closeFolder();
+        })
+    })
+
+    document.querySelectorAll("#collapse_all").forEach(btn => {
+        btn.addEventListener("click", () => {
+            const filesPanel = document.querySelector(".explorer-elements[data-tab='files']");
+            if (!filesPanel) return;
+            const expandedDirs = filesPanel.querySelectorAll(".dir.expanded");
+            expandedDirs.forEach(dir => {
+                dir.classList.remove("expanded");
+                const folderImg = dir.querySelector(".dir-title .folder-icon");
+                if (folderImg) {
+                    const folderName = dir.querySelector(".dir-title .explorer-name")?.textContent || "";
+                    folderImg.src = getFolderIconUrl(folderName, false);
+                }
+            });
         })
     })
 })

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -30,7 +30,6 @@ import { handleHistoryTab } from "../assets/js/explorerTabsHandlers/history.js"
 import { handleBugsTab } from "../assets/js/explorerTabsHandlers/bugs.js"
 import { getFolderIconUrl } from "../assets/js/iconRegistry.js"
 import { electronAPI, getDirname, readSettings } from "../assets/js/global.js"
-import { closeAllTabs } from "../assets/js/explorerTree/tabHandler.js"
 
 import { handleSettings } from "../assets/js/settings.js"
 import { SidebarResizeHandler } from "../assets/js/handlers/SidebarResizeHandler.js"
@@ -199,9 +198,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (localData.nonAccountMode) {
         loader?.classList.add("hidden");
 
-        yourOrganizationsPopupItem?.classList.add("disabled")
-        logoutPopupItem?.classList.add("disabled")
-        createOrgPopupItem?.classList.add("disabled")
+        yourOrganizationsPopupItem.classList.add("disabled")
+        logoutPopupItem.classList.add("disabled")
+        createOrgPopupItem.classList.add("disabled")
 
         topbarCenterUserData.querySelector("#username").textContent = gls.get("notAuth")
         topbarCenterUserData.querySelector("#current_hours").classList.add("v-hidden")
@@ -442,19 +441,18 @@ document.addEventListener("DOMContentLoaded", async () => {
         })
     })
 
-    document.querySelectorAll("#collapse_all").forEach(btn => {
-        btn.addEventListener("click", () => {
-            const filesPanel = document.querySelector(".explorer-elements[data-tab='files']");
-            if (!filesPanel) return;
-            const expandedDirs = filesPanel.querySelectorAll(".dir.expanded");
-            expandedDirs.forEach(dir => {
-                dir.classList.remove("expanded");
-                const folderImg = dir.querySelector(".dir-title .folder-icon");
-                if (folderImg) {
-                    const folderName = dir.querySelector(".dir-title .explorer-name")?.textContent || "";
-                    folderImg.src = getFolderIconUrl(folderName, false);
-                }
-            });
-        })
+    document.querySelector("#collapse_all").addEventListener("click", () => {
+        const filesPanel = document.querySelector(".explorer-elements[data-tab='files']");
+        if (!filesPanel) return;
+        const expandedDirs = filesPanel.querySelectorAll(".dir.expanded");
+        expandedDirs.forEach(dir => {
+            dir.classList.remove("expanded");
+            const folderImg = dir.querySelector(".dir-title .folder-icon");
+            if (folderImg) {
+                const folderName = dir.querySelector(".dir-title .explorer-name")?.textContent || "";
+                folderImg.src = getFolderIconUrl(folderName, false);
+            }
+        });
+    })
     })
 })

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -695,6 +695,18 @@ body.explorer-resizing {
     cursor: pointer;
 }
 
+.collapse-all-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+}
+.collapse-all-button svg {
+    width: 16px;
+    height: 16px;
+}
+
 .explorer-elements {
     box-sizing: border-box;
     padding: 15px;

--- a/html/index.html
+++ b/html/index.html
@@ -191,6 +191,13 @@
                     <span class="material-symbols-rounded bounce-on-hover outline" id="open_folder" visibleOn="tab:files">folder_open</span>
                     <span class="material-symbols-rounded bounce-on-hover outline" id="add_bug" visibleOn="tab:bugs">add</span>
                     <span class="material-symbols-rounded bounce-on-hover outline" id="refresh_bugs" visibleOn="tab:bugs">sync</span>
+                    <span class="collapse-all-button bounce-on-hover" id="collapse_all" visibleOn="tab:files">
+                        <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                            <path d="M14 4.27051C14.5999 4.62053 15 5.26009 15 6V11C15 13.21 13.21 15 11 15H6C5.26009 15 4.62053 14.5999 4.27051 14H11C12.65 14 14 12.65 14 11V4.27051Z"/>
+                            <path d="M9.5 7C9.776 7 10 7.224 10 7.5C10 7.776 9.776 8 9.5 8H5.5C5.224 8 5 7.776 5 7.5C5 7.224 5.224 7 5.5 7H9.5Z"/>
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M11 2C12.103 2 13 2.897 13 4V11C13 12.103 12.103 13 11 13H4C2.897 13 2 12.103 2 11V4C2 2.897 2.897 2 4 2H11ZM4 3C3.449 3 3 3.449 3 4V11C3 11.552 3.449 12 4 12H11C11.551 12 12 11.552 12 11V4C12 3.449 11.551 3 11 3H4Z"/>
+                        </svg>
+                    </span>
                 </div>
             </div>
             <div class="explorer-elements" data-tab="files">


### PR DESCRIPTION
Adds a collapse all button to the explorer panel header that collapses all expanded directories at once.