### PR TITLE
fix: crash in addToBug when priority is undefined or NaN

### DIFF
--- a/assets/js/lib.js
+++ b/assets/js/lib.js
@@ -216,7 +216,7 @@ export function addToHistory({ id, actionType, value, desc, today }) {
 
 export function addToBug({ id, priority, value, desc, today, isSelf, org, resolved, author, assignedTo, type }) {
     const bugID = id != undefined ? id : Object.keys(bugsObject).length + 1
-    const bugPriority = priority != undefined ? priority : 0
+    const bugPriority = (priority != undefined && !Number.isNaN(priority)) ? priority : 0
     const bugDesc = desc != undefined ? desc : "No description provided"
     const bugToday = today != undefined ? today : new Date().format("H:i")
     const bugIsSelf = isSelf != undefined ? isSelf : false
@@ -224,7 +224,8 @@ export function addToBug({ id, priority, value, desc, today, isSelf, org, resolv
     const bugAuthor = author != undefined ? author : false
     const bugAssignedTo = assignedTo != undefined ? assignedTo : {}
 
-    addToHistory({ actionType: "bug-added", value: value, desc: `Bug "${value}" added with ${priorityClasses[String(priority)].name} priority` });
+    const priorityInfo = priorityClasses[String(bugPriority)] || priorityClasses["0"]
+    addToHistory({ actionType: "bug-added", value: value, desc: `Bug "${value}" added with ${priorityInfo.name} priority` });
 
     bugsObject[bugID] = {
         id: bugID,


### PR DESCRIPTION
## Bug

`addToBug` in `assets/js/lib.js` crashed with `TypeError: Cannot read properties of undefined (reading 'name')` when called without a `priority` argument or when `priority` was `NaN`.

### Root cause

The function carefully created a sanitized `bugPriority` with a default of `0`, but the `addToHistory` call on line 227 used the **raw** `priority` parameter instead:

```js
const bugPriority = priority != undefined ? priority : 0  // sanitized
// ...
addToHistory({ ..., desc: `Bug "${value}" added with ${priorityClasses[String(priority)].name} priority` });
//                                                                     ^^^^^^^^ raw priority, not bugPriority
```

When `priority` was `undefined`: `priorityClasses["undefined"]` = `undefined` -> `.name` throws.

When `priority` was `NaN` (e.g. from `parseInt(bug.priority)` in `appendBugs.js:14` when the API returned a non-numeric value): `priorityClasses["NaN"]` = `undefined` -> same crash.

### Fix

- Use `bugPriority` (sanitized) instead of raw `priority` in the `addToHistory` call
- Add `!Number.isNaN(priority)` check to the `bugPriority` assignment so `NaN` also falls back to `0`
- Add a fallback `|| priorityClasses["0"]` in case the priority string is not in the map

This has been present since the earliest versions of the project.
