### PR TITLE
fix: invert isPackaged logic and fix updateLocalAppData file path

### DIFF
--- a/app/main/helpers/requests.js
+++ b/app/main/helpers/requests.js
@@ -193,7 +193,7 @@ async function readFileContent(filePath, encoding = 'utf8') {
     return data;
 }
 function updateLocalAppData(newData) {
-    const filePath = path.join(__dirname, "local.json");
+    const filePath = LOCAL_FILE_PATH;
 
     let currentData = {};
     if (fs.existsSync(filePath)) {

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -82,7 +82,7 @@ async function createWindow() {
     const localData = getLocalAppData();
     const settingsData = getSettingsData()
     const appIcon = await getAppIcon();
-    const isPackaged = !app.isPackaged;
+    const isPackaged = app.isPackaged;
     const primaryDisplay = screen.getPrimaryDisplay();
     const { width, height } = primaryDisplay.workAreaSize;
 


### PR DESCRIPTION
## Fixes

### #2 Inverted `isPackaged` logic — `app/main/main.ts:84`

```js
const isPackaged = !app.isPackaged;  // true when NOT packaged — inverted!
```

The variable stored the **opposite** of its name: `true` when the app was running in dev mode, `false` when packaged. The variable was unused so far, but this is a latent bug waiting to happen. Fixed to `app.isPackaged`.

### #3 `updateLocalAppData` writes to wrong file — `app/main/helpers/requests.js:196`

```js
const filePath = path.join(__dirname, "local.json");  // app/main/helpers/local.json
```

All other functions in the file use `LOCAL_FILE_PATH` (which is `userData/local.json`) — already imported at the top. But `updateLocalAppData` wrote to `__dirname/local.json` instead, meaning the data was written to the wrong location and never read back by `getLocalAppData`. Fixed to use `LOCAL_FILE_PATH`.

Both bugs have been present since the earliest versions of the project.
