### PR TITLE
fix: prune gitignored directories

### DIFF
--- a/app/main/helpers/gitignore.js
+++ b/app/main/helpers/gitignore.js
@@ -1,0 +1,32 @@
+const fsPromise = require("fs/promises")
+const path = require("path")
+const ignore = require("ignore")
+
+async function loadGitignore(rootPath) {
+    try {
+        const content = await fsPromise.readFile(path.join(rootPath, ".gitignore"), "utf8")
+        return {
+            matcher: ignore().add(content),
+            canPrune: !content.split(/\r?\n/).some(line => /^\s*!/.test(line))
+        }
+    } catch (error) {
+        if (error.code === "ENOENT") return { matcher: ignore(), canPrune: true }
+        throw error
+    }
+}
+
+function getGitignorePath(rootPath, targetPath) {
+    const relative = path.relative(rootPath, targetPath).replace(/\\/g, "/")
+
+    if (!relative || relative.startsWith("../") || relative === "..") return null
+    return relative
+}
+
+function isIgnored(targetPath, rootPath, rules, isDirectory = false) {
+    const relative = getGitignorePath(rootPath, targetPath)
+    if (!relative) return false
+
+    return rules.matcher.ignores(isDirectory ? `${relative}/` : relative)
+}
+
+module.exports = { loadGitignore, isIgnored }

--- a/app/main/helpers/os.js
+++ b/app/main/helpers/os.js
@@ -1,6 +1,7 @@
 const { dialog } = require("electron")
 const fsPromise = require('fs/promises');
 const path = require("path")
+const { loadGitignore, isIgnored } = require("./gitignore")
 
 function selectFile(win) {
     const result = dialog.showOpenDialogSync(win, {
@@ -36,7 +37,7 @@ async function readDirTree(rootPath, options = {}) {
     const absRoot = path.resolve(rootPath);
     const maxDepth = Number.isInteger(options.maxDepth) ? options.maxDepth : Infinity;
     const ignoreRoot = path.resolve(options.ignoreRoot || absRoot);
-    const ignoreRules = await readIgnoreRules(ignoreRoot);
+    const ignoreRules = await loadGitignore(ignoreRoot);
 
     async function walk(dir, depth = 0) {
         let entries = [];
@@ -46,10 +47,13 @@ async function readDirTree(rootPath, options = {}) {
 
             for (const d of dirents) {
                 const full = path.join(dir, d.name);
-                const item = { name: d.name, path: full, ignored: isIgnored(full, d.isDirectory(), ignoreRoot, ignoreRules) };
+                const isDirectory = d.isDirectory();
+                const item = { name: d.name, path: full, ignored: isIgnored(full, ignoreRoot, ignoreRules, isDirectory) };
 
-                if (d.isDirectory()) {
-                    if (depth < maxDepth) {
+                if (isDirectory) {
+                    if (item.ignored && ignoreRules.canPrune) {
+                        entries.push({ ...item, type: 'dir', loaded: false });
+                    } else if (depth < maxDepth) {
                         const children = await walk(full, depth + 1);
                         entries.push({ ...item, type: 'dir', children, loaded: true });
                     } else {
@@ -101,45 +105,4 @@ module.exports = {
     selectFolder,
     saveFile,
     readDirTree
-}
-
-async function readIgnoreRules(rootPath) {
-    try {
-        const content = await fsPromise.readFile(path.join(rootPath, ".gitignore"), "utf8");
-        return content
-            .split(/\r?\n/)
-            .map(line => line.trim())
-            .filter(line => line && !line.startsWith("#"))
-            .map(line => line.replace(/\\/g, "/"));
-    } catch (_) {
-        return [];
-    }
-}
-
-function isIgnored(targetPath, isDir, rootPath, rules) {
-    const relative = path.relative(rootPath, targetPath).replace(/\\/g, "/");
-    if (!relative || relative.startsWith("..")) return false;
-
-    const name = path.basename(targetPath);
-
-    return rules.some(rule => {
-        let pattern = rule;
-        let dirOnly = pattern.endsWith("/");
-
-        if (pattern.startsWith("!")) return false;
-        pattern = pattern.replace(/^\/+/, "").replace(/\/+$/, "");
-        if (!pattern) return false;
-
-        const target = pattern.includes("/") ? relative : name;
-
-        if (dirOnly && !isDir) return false;
-        if (target === pattern || relative === pattern || relative.startsWith(`${pattern}/`)) return true;
-
-        if (pattern.includes("*")) {
-            const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
-            return new RegExp(`^${escaped}$`).test(target);
-        }
-
-        return false;
-    });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "chokidar": "^5.0.0",
                 "error-stack-parser": "^2.1.4",
                 "flashot": "^1.4.1",
+                "ignore": "^7.0.6",
                 "node-global-key-listener": "^0.3.0",
                 "node-gyp": "^12.4.0",
                 "oxc-parser": "^0.140.0",
@@ -3396,6 +3397,15 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/inflight": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "main": "app/dist/main.js",
     "scripts": {
         "build": "tsc && tsc -p tsconfig.esm.json",
+        "test": "node --test tests/unit/*.test.mjs",
         "cdbuild": "cd codemirror && npm i && npm run build",
         "start": "npm run cdbuild && npm run build && electron .",
         "dist": "npm run cdbuild && npm run build && electron-builder",
@@ -59,6 +60,7 @@
         "chokidar": "^5.0.0",
         "error-stack-parser": "^2.1.4",
         "flashot": "^1.4.1",
+        "ignore": "^7.0.6",
         "node-global-key-listener": "^0.3.0",
         "node-gyp": "^12.4.0",
         "oxc-parser": "^0.140.0",

--- a/tests/unit/gitignore.test.mjs
+++ b/tests/unit/gitignore.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { createRequire } from "node:module"
+
+const require = createRequire(import.meta.url)
+const { loadGitignore, isIgnored } = require("../../app/main/helpers/gitignore.js")
+
+function loadOsHelper() {
+    const electronPath = require.resolve("electron")
+    const electronModule = require.cache[electronPath]
+    require.cache[electronPath] = { exports: { dialog: {} } }
+
+    try {
+        return require("../../app/main/helpers/os.js")
+    } finally {
+        if (electronModule) require.cache[electronPath] = electronModule
+        else delete require.cache[electronPath]
+    }
+}
+
+test("supports gitignore directory, globstar, and negation rules", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "codemotion-gitignore-"))
+    const rules = await fs.writeFile(
+        path.join(root, ".gitignore"),
+        "node_modules/\n**/*.log\n!important.log\n",
+        "utf8"
+    ).then(() => loadGitignore(root))
+
+    assert.equal(isIgnored(path.join(root, "node_modules"), root, rules, true), true)
+    assert.equal(isIgnored(path.join(root, "node_modules", "package.json"), root, rules), true)
+    assert.equal(isIgnored(path.join(root, "logs", "debug.log"), root, rules), true)
+    assert.equal(isIgnored(path.join(root, "important.log"), root, rules), false)
+    assert.equal(isIgnored(path.join(root, "src", "index.js"), root, rules), false)
+    assert.equal(rules.canPrune, false)
+})
+
+test("returns an empty matcher when .gitignore is missing", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "codemotion-gitignore-"))
+    const rules = await loadGitignore(root)
+
+    assert.equal(isIgnored(path.join(root, "node_modules"), root, rules), false)
+    assert.equal(rules.canPrune, true)
+})
+
+test("prunes ignored directories instead of reading their contents", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "codemotion-gitignore-"))
+    await fs.mkdir(path.join(root, "node_modules", "nested"), { recursive: true })
+    await fs.writeFile(path.join(root, ".gitignore"), "node_modules/\n", "utf8")
+    await fs.writeFile(path.join(root, "node_modules", "nested", "hidden.js"), "", "utf8")
+    await fs.writeFile(path.join(root, "visible.js"), "", "utf8")
+
+    const { readDirTree } = loadOsHelper()
+    const entries = await readDirTree(root)
+    const ignored = entries.find(entry => entry.name === "node_modules")
+
+    assert.equal(ignored.ignored, true)
+    assert.equal(ignored.loaded, false)
+    assert.equal(ignored.children, undefined)
+})


### PR DESCRIPTION
## Summary

- Replace the ad-hoc gitignore matcher with the `ignore` package.
- Stop recursively reading ignored directories when no negation rules can re-include content.
- Add unit coverage for directory rules, globstar, negation, missing `.gitignore`, and directory pruning.
- Add the missing `npm test` script.

## Verification

- `npm test`
- `npm run build`

Fixes the explorer performance issue where ignored directories such as `node_modules` and `.git` were fully traversed and only hidden with CSS.
