### PR TITLE
fix: position context menus with UI scale

### DIFF
--- a/assets/js/explorerTree/handlers/contextMenuHandler.js
+++ b/assets/js/explorerTree/handlers/contextMenuHandler.js
@@ -4,6 +4,7 @@ import { copyText, normalizePath } from "../../lib.js";
 import { closeTab, updateTabPath } from "../tabHandler.js";
 import { renderNodes } from "../render.js";
 import { bindFileClicks } from "./bindFileClicksHandler.js";
+import { getContextMenuPosition } from "../../handlers/contextMenuPosition.js";
 
 let menuEl = null;
 
@@ -124,14 +125,18 @@ function showMenu(event, items) {
         menu.classList.remove("closing");
     }
 
-    const edgeGap = 8;
-    const maxLeft = window.innerWidth - menu.offsetWidth - edgeGap;
-    const maxTop = window.innerHeight - menu.offsetHeight - edgeGap;
-    const left = Math.max(edgeGap, Math.min(event.clientX, maxLeft));
-    const top = Math.max(edgeGap, Math.min(event.clientY, maxTop));
+    const position = getContextMenuPosition({
+        clientX: event.clientX,
+        clientY: event.clientY,
+        menuWidth: menu.offsetWidth,
+        menuHeight: menu.offsetHeight,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+        zoom: getComputedStyle(document.body).zoom,
+    });
 
-    menu.style.left = `${left}px`;
-    menu.style.top = `${top}px`;
+    menu.style.left = `${position.left}px`;
+    menu.style.top = `${position.top}px`;
 }
 
 async function refreshFolder(dirElement, context) {

--- a/assets/js/handlers/contextMenuHandler.js
+++ b/assets/js/handlers/contextMenuHandler.js
@@ -1,4 +1,5 @@
 import { idify } from "../lib.js"
+import { getContextMenuPosition } from "./contextMenuPosition.js"
 
 export class ContextMenu {
     constructor(id, elements = {}) {
@@ -83,10 +84,17 @@ export class ContextMenu {
     _show(x, y) {
         const menuW = this.context.offsetWidth || 250;
         const menuH = this.context.offsetHeight || 300;
-        if (x + menuW > window.innerWidth) x = window.innerWidth - menuW - 5;
-        if (y + menuH > window.innerHeight) y = window.innerHeight - menuH - 5;
-        this.context.style.left = x + "px";
-        this.context.style.top = y + "px";
+        const position = getContextMenuPosition({
+            clientX: x,
+            clientY: y,
+            menuWidth: menuW,
+            menuHeight: menuH,
+            viewportWidth: window.innerWidth,
+            viewportHeight: window.innerHeight,
+            zoom: getComputedStyle(document.body).zoom,
+        });
+        this.context.style.left = position.left + "px";
+        this.context.style.top = position.top + "px";
         if (this.context.classList.contains("hidden")) {
             this.context.classList.add("closing");
             this.context.classList.remove("hidden");

--- a/assets/js/handlers/contextMenuPosition.js
+++ b/assets/js/handlers/contextMenuPosition.js
@@ -1,0 +1,12 @@
+export function getContextMenuPosition({ clientX, clientY, menuWidth, menuHeight, viewportWidth, viewportHeight, zoom = 1, edgeGap = 8 }) {
+    const scale = Number(zoom) > 0 ? Number(zoom) : 1;
+    const x = clientX / scale;
+    const y = clientY / scale;
+    const maxLeft = Math.max(edgeGap, viewportWidth / scale - menuWidth - edgeGap);
+    const maxTop = Math.max(edgeGap, viewportHeight / scale - menuHeight - edgeGap);
+
+    return {
+        left: Math.min(Math.max(edgeGap, x), maxLeft),
+        top: Math.min(Math.max(edgeGap, y), maxTop),
+    };
+}

--- a/tests/unit/contextMenuPosition.test.mjs
+++ b/tests/unit/contextMenuPosition.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getContextMenuPosition } from "../../assets/js/handlers/contextMenuPosition.js";
+
+const viewport = { viewportWidth: 1000, viewportHeight: 800, menuWidth: 200, menuHeight: 120 };
+
+test("maps client coordinates into the body zoom coordinate system", () => {
+    assert.deepEqual(getContextMenuPosition({
+        ...viewport,
+        clientX: 500,
+        clientY: 300,
+        zoom: 2,
+    }), { left: 250, top: 150 });
+});
+
+test("keeps a zoomed menu inside the viewport", () => {
+    assert.deepEqual(getContextMenuPosition({
+        ...viewport,
+        clientX: 990,
+        clientY: 790,
+        zoom: 2,
+    }), { left: 292, top: 272 });
+});
+
+test("falls back to normal scale for invalid zoom values", () => {
+    assert.deepEqual(getContextMenuPosition({
+        ...viewport,
+        clientX: 500,
+        clientY: 300,
+        zoom: 0,
+    }), { left: 500, top: 300 });
+});


### PR DESCRIPTION
## Summary
- fix context menu coordinates when the UI scale is not 1
- apply the same viewport clamping to Explorer and Editor menus
- add unit coverage for scaled coordinates and viewport boundaries

## Verification
- npm test
- npm run build
