### PR TITLE
fix: restore editor theme contrast

### DIFF
--- a/assets/css/components/codeWrapper.css
+++ b/assets/css/components/codeWrapper.css
@@ -143,7 +143,7 @@ body.bottom-window-resizing {
 .bottom-window__resize-preview {
     position: fixed;
     height: 2px;
-    border-top: 2px solid rgba(255, 255, 255, .9);
+    border-top: 2px solid var(--text-color);
     box-shadow: 0 0 0 1px rgba(0, 0, 0, .45);
     pointer-events: none;
     z-index: 9999;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -754,7 +754,7 @@ body.explorer-resizing {
     display: block;
     width: 5px;
     height: 5px;
-    background: white;
+    background: var(--text-color);
     border-radius: 100%;
     margin-top: 3px;
     margin-right: 8px;

--- a/assets/css/themes/light.theme.css
+++ b/assets/css/themes/light.theme.css
@@ -5,16 +5,17 @@ body[theme="light"] {
     --topbar-color: #efefef;
     --block-divider-border-color: #e1e1e1;
     --text-color: #000000;
-    --text-color-muted: #c1c1c1;
-    --topbar-menu-item-hover-bg: #000000;
+    --text-color-muted: #626262;
+    --code-background: #ffffff;
+    --topbar-menu-item-hover-bg: #00000012;
     --explorer-padding: 0px 15px;
     --switch-bg-default: #ffffff;
     --switch-bg-active: #ffffff;
     --switch-inner-default: #fff;
     --switch-inner-active: #ffffff;
-    --explorer-tabs-bg: linear-gradient(0deg, #ffffff00, #ffffff14);
-    --explorer-tabs-border: radial-gradient(#ffffff4a, transparent);
-    --explorer-tabs-color: white;
+    --explorer-tabs-bg: linear-gradient(0deg, #ffffff00, #0000000a);
+    --explorer-tabs-border: radial-gradient(#00000024, transparent);
+    --explorer-tabs-color: #000000;
     --default-badge-bg: #e5903624;
     --default-badge-text: #e59036;
     --segment-bg: #ffffff;
@@ -52,6 +53,14 @@ body[theme="light"] .explorer-elements .file::after {
     background: linear-gradient(270deg, var(--topbar-color) 20%, transparent);
 }
 body[theme="light"] .explorer-elements .file.active {
+    background: #00000012;
+}
+
+body[theme="light"] .explorer-tabs {
+    backdrop-filter: blur(10px) brightness(1);
+}
+
+body[theme="light"] .code-tab span:hover {
     background: #00000012;
 }
 

--- a/codemirror/src/themes/overrides.js
+++ b/codemirror/src/themes/overrides.js
@@ -10,10 +10,10 @@ export const vscodeDarkOverride = EditorView.theme({
 });
 export const atomoneOverride = EditorView.theme({
     "&": {
-        backgroundColor: "#26262b!important"
+        backgroundColor: "#000000!important"
     },
     ".cm-gutters": {
-        backgroundColor: "#0b0b0b!important"
+        backgroundColor: "#000000!important"
     }
 });
 export const githubDarkOverride = EditorView.theme({

--- a/codemirror/src/themes/overrides.js
+++ b/codemirror/src/themes/overrides.js
@@ -10,10 +10,10 @@ export const vscodeDarkOverride = EditorView.theme({
 });
 export const atomoneOverride = EditorView.theme({
     "&": {
-        backgroundColor: "#000000!important"
+        backgroundColor: "#040404!important"
     },
     ".cm-gutters": {
-        backgroundColor: "#000000!important"
+        backgroundColor: "#040404!important"
     }
 });
 export const githubDarkOverride = EditorView.theme({


### PR DESCRIPTION
## Summary
- fix unreadable tabs and bottom editor controls in Light Theme
- restore black editor background for Contrast dark
- keep theme-dependent indicators and resize feedback visible

## Verification
- npm test
- npm run build (in codemirror)
- git diff --check