### PR TITLE
Fix absolute path resolution in explorer tree context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ codemirror/node_modules
 package-lock.json
 pnpm-lock.yaml
 dist-esm/
+.gigacode

--- a/app/main/helpers/terminal.ts
+++ b/app/main/helpers/terminal.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync, ChildProcess } from 'child_process';
-import { ipcMain, IpcMainEvent } from 'electron';
+import {ipcMain, IpcMainEvent, shell} from 'electron';
 import fs from 'fs';
 import os from 'os';
 
@@ -38,7 +38,7 @@ class TerminalManager {
         const fallback = os.homedir();
 
         if (!cwd || !fs.existsSync(cwd)) {
-            console.log("[Terminal] Path does not exist, using home directory: " + fallback);
+            console.log("[Terminal] Path does notenv. exist, using home directory: " + fallback);
             return fallback;
         }
 

--- a/assets/js/explorerTree/handlers/openFolderHandler.js
+++ b/assets/js/explorerTree/handlers/openFolderHandler.js
@@ -1,9 +1,8 @@
-import { closeAllTabs } from "../tabHandler.js";
-import { buildTreeHtml, renderNodes } from "../render.js";
-import { bindFileClicks } from "./bindFileClicksHandler.js";
-import { tabsByPath, recentlyClosed } from "../tabHandler.js";
-import { initializeExplorerContextMenu } from "./contextMenuHandler.js";
-import { getFolderIconUrl } from "../../iconRegistry.js";
+import {closeAllTabs, recentlyClosed, tabsByPath} from "../tabHandler.js";
+import {buildTreeHtml, renderNodes} from "../render.js";
+import {bindFileClicks} from "./bindFileClicksHandler.js";
+import {initializeExplorerContextMenu} from "./contextMenuHandler.js";
+import {getFolderIconUrl} from "../../iconRegistry.js";
 
 async function setProjectDataUsedLanguages(path) {
     const usedLanguages = await window.electron.getUsedLanguagesByPath(path)
@@ -110,7 +109,8 @@ export async function openFolder({ pathRoot, filesPanel, addToHistory, pathConte
 
 function updatePathContext({ pathRoot, pathContext }) {
     const parts = pathRoot.split(/[\\/]/g).filter(Boolean);
-    pathContext["rootPath"] = parts.join("/");
+    const isAbsolute = pathRoot.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(pathRoot);
+    pathContext["rootPath"] = isAbsolute ? "/" + parts.join("/") : parts.join("/");
     pathContext["root"] = parts.pop();
 }
 


### PR DESCRIPTION
Corrected path context handling for absolute paths by prepending a slash

Fixed: On Linux/macOS, the leading slash was being removed when split, causing terminal failures.
Now, if the original path contained an initial slash, it is added to the start of rootPath.