### PR TITLE
feat: interactive PTY terminal, Biome tooling setup, and expanded build targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build-windows:
-    name: Windows (NSIS)
+    name: Windows
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -33,11 +33,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-build
-          path: dist/*.exe
+          path: |
+            dist/*.exe
+            dist/*.zip
           retention-days: 1
 
   build-mac:
-    name: macOS (DMG)
+    name: macOS
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -59,11 +61,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mac-build
-          path: dist/*.dmg
+          path: |
+            dist/*.dmg
+            dist/*.zip
           retention-days: 1
 
   build-linux:
-    name: Linux (AppImage)
+    name: Linux
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -85,33 +89,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linux-build
-          path: dist/*.AppImage
-          retention-days: 1
-
-  build-linux-portable:
-    name: Linux (Portable)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build & package
-        run: npm run dist-linux-portable -- --publish never
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-portable-build
-          path: dist/*.tar.gz
+          path: |
+            dist/*.AppImage
+            dist/*.deb
+            dist/*.rpm
+            dist/*.pkg.tar.zst
+            dist/*.tar.gz
           retention-days: 1
 
   build-flatpak:
@@ -172,7 +155,7 @@ jobs:
 
   release:
     name: Publish Release
-    needs: [build-windows, build-mac, build-linux, build-linux-portable, build-flatpak]
+    needs: [build-windows, build-mac, build-linux, build-flatpak]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ package-lock.json
 pnpm-lock.yaml
 dist-esm/
 .gigacode
+bun.lock
+bun.lockb

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.biome": "explicit"
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[json]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ We love contributions! Whether it's bug reports, feature requests, or pull reque
 
 - Fork the repository
 - Create your feature branch ```git checkout -b feature/AmazingFeature```
+- Ensure code quality and formatting:
+  ```bash
+  npm run lint       # Run linter checks
+  npm run format     # Format code with Biome
+  npm test           # Run tests
+  ```
 - Commit your changes ```git commit -m 'Add some AmazingFeature'```
 - Push to the branch ```git push origin feature/AmazingFeature```
 - Open a Pull Request

--- a/README.md
+++ b/README.md
@@ -25,16 +25,15 @@ with native tools for web developers</p>
 
 > [!IMPORTANT]
 > **macOS: "CodeMotion is damaged and can't be opened"** — this is NOT corruption. The build isn't signed with a paid Apple Developer certificate, so macOS Gatekeeper quarantines it. To fix, drag the app to `/Applications`, then run this once in Terminal:
+>
 > ```bash
 > xattr -cr /Applications/CodeMotion.app
 > ```
+>
 > The app will open normally afterwards.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
-
-
-
 
 ## ✨ Features
 
@@ -47,9 +46,11 @@ with native tools for web developers</p>
 - **Extensible**: Easily customize and extend with own easy plugins engine
 
 ## 🎯 Quick Start
+
 [If you're new here, check out our beginner's guide](https://codemotion.yurba.one/docs#for-beginners/FOR_BEGINNERS_BUILD_APP)
 
 Prerequisites:
+
 - Node.js (v20 or higher)
 - npm
 
@@ -69,6 +70,7 @@ npm start
 # Or with dev mode
 npm start -- --d
 ```
+
 ## 🏗️ Project Structure
 
 ```
@@ -80,6 +82,7 @@ codemotion-ide/
 ├── html/                # HTML Templates
 └── languages/           # App languages in JSON
 ```
+
 ## 🛠️ Stack
 
 - **Backend**: TypeScript
@@ -87,23 +90,28 @@ codemotion-ide/
 - **Styling**: Pure CSS
 - **Markup**: HTML
 - **Architecture**: Modular & Component-based
+
 ## 🤝 Contributing
 
 We love contributions! Whether it's bug reports, feature requests, or pull requests, we welcome your involvement.
 
 #### Contributing Guidelines
+
 - Fork the repository
 - Create your feature branch ```git checkout -b feature/AmazingFeature```
 - Commit your changes ```git commit -m 'Add some AmazingFeature'```
 - Push to the branch ```git push origin feature/AmazingFeature```
 - Open a Pull Request
+
 ## 📝 License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
+
 ## Authors
 
 - [@cdmtn-dev](https://github.com/cdmtn-dev)
 
 ## Special thanks
+
 - [@noxy](https://github.com/noxygalaxy) (Super contributor)
 - [@NotKiwy](https://github.com/NotKiwy) (Triage)

--- a/app/main/helpers/terminal.ts
+++ b/app/main/helpers/terminal.ts
@@ -1,22 +1,22 @@
-import { spawn, spawnSync, ChildProcess } from 'child_process';
-import {ipcMain, IpcMainEvent, shell} from 'electron';
+import * as pty from 'node-pty';
+import { ipcMain, IpcMainEvent } from 'electron';
 import fs from 'fs';
 import os from 'os';
 
-type TerminalInputHandler = (event: IpcMainEvent, input: string) => void
-
 class TerminalManager {
-    activeProcess: ChildProcess | null
-    inputHandler: TerminalInputHandler | null
+    ptyProcess: pty.IPty | null;
 
     constructor() {
-        this.activeProcess = null;
-        this.inputHandler = null;
+        this.ptyProcess = null;
     }
 
     getShell(): string {
         if (process.platform === 'win32') {
-            return 'cmd.exe';
+            const powerShell = `${process.env.SystemRoot || 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+            if (fs.existsSync(powerShell)) {
+                return powerShell;
+            }
+            return process.env.COMSPEC || 'cmd.exe';
         }
 
         const userShell = process.env.SHELL;
@@ -38,231 +38,142 @@ class TerminalManager {
         const fallback = os.homedir();
 
         if (!cwd || !fs.existsSync(cwd)) {
-            console.log("[Terminal] Path does notenv. exist, using home directory: " + fallback);
             return fallback;
         }
 
-        const stat = fs.statSync(cwd);
-
-        if (stat.isFile()) {
-            const path = require('path');
-            const dirname = path.dirname(cwd);
-            console.log(`[Terminal] Path is a file, using directory: ${dirname}`);
-            return dirname;
+        try {
+            const stat = fs.statSync(cwd);
+            if (stat.isFile()) {
+                const path = require('path');
+                return path.dirname(cwd);
+            }
+            if (stat.isDirectory()) {
+                return cwd;
+            }
+        } catch {
+            return fallback;
         }
 
-        if (stat.isDirectory()) {
-            return cwd;
-        }
-
-        console.log("[Terminal] Path is neither file nor directory, using home directory: " + fallback);
         return fallback;
     }
 
-    handleOutput(data: Buffer, type: 'stdout' | 'stderr', event: IpcMainEvent): void {
-        const output = data.toString();
-        const prefix = type === 'stderr' ? '[ERR] ' : '';
-
-        console.log(`[Terminal ${type}] ${output}`);
-
-        event.sender.send("terminal-result", {
-            type: type === 'stderr' ? 'error' : 'output',
-            data: prefix + output,
-            timestamp: Date.now()
-        });
-    }
-
-    cleanupInputHandler(): void {
-        if (this.inputHandler) {
-            ipcMain.removeListener("terminal-input", this.inputHandler);
-            this.inputHandler = null;
-        }
-    }
-
-    terminateProcess(): void {
-        if (this.activeProcess && !this.activeProcess.killed) {
-            this.killProcessTree(false);
-        }
-    }
-
-    killProcessTree(force = true): void {
-        if (!this.activeProcess || this.activeProcess.killed) return;
-
-        const pid = this.activeProcess.pid;
-
-        try {
-            if (process.platform === 'win32') {
-                const args = ['/pid', String(pid), '/T'];
-                if (force) args.push('/F');
-
-                spawnSync('taskkill.exe', args, {
-                    windowsHide: true,
-                    stdio: 'ignore'
-                });
-            } else {
-                this.activeProcess.kill(force ? 'SIGKILL' : 'SIGTERM');
-            }
-        } catch (err: any) {
-            console.error(`[Terminal] Error killing process tree: ${err.message}`);
-        }
-    }
-
-    executeCommand(event: IpcMainEvent, data: { cmd: string; cwd: string }): void {
-        const { cmd, cwd } = data;
-
-        if (this.activeProcess) {
-            event.sender.send("terminal-result", {
-                type: 'warning',
-                data: 'Another process is already running. Kill it first.\r\n'
-            });
-            return;
+    initSession(event: IpcMainEvent, data: { cwd?: string; cols?: number; rows?: number }): void {
+        if (this.ptyProcess) {
+            this.killProcessTree();
         }
 
-        const workDir = this.validateWorkDir(cwd);
+        const workDir = this.validateWorkDir(data?.cwd || '');
         const shell = this.getShell();
+        const cols = data?.cols || 80;
+        const rows = data?.rows || 24;
 
-        console.log(`[Terminal] Executing command: "${cmd}" in "${workDir}"`);
-        console.log(`[Terminal] Using shell: ${shell}`);
+        console.log(`[Terminal PTY] Spawning shell: ${shell} in "${workDir}" (cols: ${cols}, rows: ${rows})`);
 
         try {
-            const isWindows = process.platform === 'win32';
-            const spawnArgs = isWindows ? ['/c', cmd] : ['-c', cmd];
-            const spawnShell = isWindows ? 'cmd.exe' : shell;
-
-            this.activeProcess = spawn(spawnShell, spawnArgs, {
+            this.ptyProcess = pty.spawn(shell, [], {
+                name: 'xterm-256color',
+                cols,
+                rows,
                 cwd: workDir,
-                shell: false,
-                stdio: ['pipe', 'pipe', 'pipe'],
                 env: {
                     ...process.env,
+                    COLORTERM: 'truecolor',
                     TERM: 'xterm-256color'
                 }
             });
 
-            if (!this.activeProcess || !this.activeProcess.pid) {
-                const errorMsg = 'Failed to spawn process - check shell path and arguments';
-                console.error(`[Terminal] ${errorMsg}`);
-                throw new Error(errorMsg);
-            }
-
-            console.log(`[Terminal] Process spawned with PID: ${this.activeProcess.pid}`);
-
-            this.activeProcess.stdout?.on("data", (data: Buffer) => {
-                this.handleOutput(data, 'stdout', event);
-            });
-
-            this.activeProcess.stderr?.on("data", (data: Buffer) => {
-                this.handleOutput(data, 'stderr', event);
-            });
-
-            this.activeProcess.on("close", (code: number | null) => {
-                console.log(`[Terminal] Process exited with code ${code}`);
-
-                event.sender.send("terminal-result", {
-                    type: 'exit',
-                    data: `\r\nProcess exited with code ${code}\r\n`,
-                    exitCode: code
-                });
-
-                this.activeProcess = null;
-                this.cleanupInputHandler();
-            });
-
-            this.activeProcess.on("error", (err: Error) => {
-                console.error(`[Terminal] Error: ${err.message}`);
-
-                event.sender.send("terminal-result", {
-                    type: 'error',
-                    data: `Error: ${err.message}\r\n`
-                });
-
-                this.activeProcess = null;
-                this.cleanupInputHandler();
-            });
-
-            this.cleanupInputHandler();
-
-            this.inputHandler = (e: IpcMainEvent, input: string) => {
-                if (this.activeProcess && !this.activeProcess.killed) {
-                    try {
-                        const inputWithNewline = input.endsWith('\n') ? input : input + '\n';
-                        this.activeProcess.stdin?.write(inputWithNewline);
-                        console.log(`[Terminal] Sent input: ${input}`);
-                    } catch (err: any) {
-                        console.error("Error writing to stdin:", err.message);
-                        event.sender.send("terminal-result", {
-                            type: 'error',
-                            data: `Error writing to stdin: ${err.message}\r\n`
-                        });
-                    }
+            this.ptyProcess.onData((data: string) => {
+                if (!event.sender.isDestroyed()) {
+                    event.sender.send("terminal-result", {
+                        type: 'output',
+                        data: data
+                    });
                 }
-            };
+            });
 
-            ipcMain.on("terminal-input", this.inputHandler);
+            this.ptyProcess.onExit(({ exitCode, signal }) => {
+                console.log(`[Terminal PTY] Process exited with code ${exitCode}, signal ${signal}`);
+                if (!event.sender.isDestroyed()) {
+                    event.sender.send("terminal-result", {
+                        type: 'exit',
+                        data: `\r\nProcess exited with code ${exitCode}\r\n`,
+                        exitCode
+                    });
+                }
+                this.ptyProcess = null;
+            });
 
         } catch (err: any) {
-            console.error(`[Terminal] Catch error: ${err.message}`);
-
+            console.error(`[Terminal PTY] Failed to spawn shell: ${err.message}`);
             event.sender.send("terminal-result", {
                 type: 'error',
-                data: `Failed to execute command: ${err.message}\r\n`
+                data: `Failed to spawn shell: ${err.message}\r\n`
             });
-
-            this.activeProcess = null;
+            this.ptyProcess = null;
         }
     }
 
-    killProcess(event: IpcMainEvent): void {
-        if (!this.activeProcess) {
-            console.log("[Terminal] No active process to kill");
-            return;
+    sendInput(input: string): void {
+        if (this.ptyProcess) {
+            this.ptyProcess.write(input);
         }
+    }
 
-        if (this.activeProcess.killed) {
-            console.log("[Terminal] Process is already killed");
-            return;
+    resize(cols: number, rows: number): void {
+        if (this.ptyProcess && cols > 0 && rows > 0) {
+            try {
+                this.ptyProcess.resize(cols, rows);
+            } catch (err: any) {
+                console.error(`[Terminal PTY] Resize error: ${err.message}`);
+            }
         }
+    }
 
-        console.log(`[Terminal] Killing process with PID: ${this.activeProcess.pid}`);
+    killProcessTree(): void {
+        if (!this.ptyProcess) return;
 
         try {
-            this.killProcessTree(false);
-
-            const forceKillTimeout = setTimeout(() => {
-                if (this.activeProcess && !this.activeProcess.killed) {
-                    console.log(`[Terminal] Force killing process`);
-                    this.killProcessTree(true);
-                }
-            }, 2000);
-
-            this.activeProcess.on('exit', () => {
-                clearTimeout(forceKillTimeout);
-            });
-
+            this.ptyProcess.kill();
         } catch (err: any) {
-            console.error(`[Terminal] Error killing process: ${err.message}`);
-            event.sender.send("terminal-result", {
-                type: 'error',
-                data: `Error killing process: ${err.message}\r\n`
-            });
+            console.error(`[Terminal PTY] Error killing process: ${err.message}`);
         }
+        this.ptyProcess = null;
+    }
+
+    cleanupInputHandler(): void {
+        // No-op for PTY session
     }
 }
 
 const terminalManager = new TerminalManager();
 
+ipcMain.on("terminal-init", (event: IpcMainEvent, data: { cwd?: string; cols?: number; rows?: number }) => {
+    terminalManager.initSession(event, data);
+});
+
+ipcMain.on("terminal-input", (_: IpcMainEvent, input: string) => {
+    terminalManager.sendInput(input);
+});
+
+ipcMain.on("terminal-resize", (_: IpcMainEvent, data: { cols: number; rows: number }) => {
+    terminalManager.resize(data.cols, data.rows);
+});
+
 ipcMain.on("terminal-command", (event: IpcMainEvent, data: { cmd: string; cwd: string }) => {
-    terminalManager.executeCommand(event, data);
+    if (!terminalManager.ptyProcess) {
+        terminalManager.initSession(event, { cwd: data.cwd });
+    }
+    if (data.cmd) {
+        terminalManager.sendInput(data.cmd + '\r');
+    }
 });
 
-ipcMain.on("terminal-kill", (event: IpcMainEvent) => {
-    terminalManager.killProcess(event);
+ipcMain.on("terminal-kill", () => {
+    terminalManager.killProcessTree();
 });
 
-ipcMain.on("terminal-cleanup", (event: IpcMainEvent) => {
-    console.log("[Terminal] Cleanup requested");
-    terminalManager.killProcessTree(true);
-    terminalManager.cleanupInputHandler();
+ipcMain.on("terminal-cleanup", () => {
+    terminalManager.killProcessTree();
 });
 
 export { TerminalManager, terminalManager };

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -97,6 +97,8 @@ contextBridge.exposeInMainWorld('electron', {
 
     onStatusUpdate: (callback: any) => ipcRenderer.on("status-update", callback),
 
+    initTerminal: (data: any) => ipcRenderer.send("terminal-init", data),
+    resizeTerminal: (data: { cols: number; rows: number }) => ipcRenderer.send("terminal-resize", data),
     sendCommand: (data: any) => ipcRenderer.send("terminal-command", data),
     sendInput: (input: any) => ipcRenderer.send("terminal-input", input),
     killProcess: () => ipcRenderer.send("terminal-kill"),

--- a/assets/js/handlers/terminalHandler.js
+++ b/assets/js/handlers/terminalHandler.js
@@ -10,17 +10,20 @@ export class Console {
                 convertEol: true,
                 cursorBlink: true,
                 fontFamily: "Consolas, monospace",
-                fontSize: 14
+                fontSize: 14,
+                allowProposedApi: true
             }
         )
 
         this.term.loadAddon(fitAddon)
         this.term.open(this.body)
         this.fitAddon = fitAddon
-        this.handleResize = () => this.fit()
         this.disposed = false
         this.fitFrame = null
         this.isPanelResizing = false
+        this.cwd = this.toDir(startPath) || ""
+
+        this.handleResize = () => this.fit()
         this.handlePanelResizeStart = () => {
             this.isPanelResizing = true
         }
@@ -35,64 +38,11 @@ export class Console {
         window.addEventListener("resize", this.handleResize)
         this.console.win.addEventListener("bottom-window-resize-start", this.handlePanelResizeStart)
         this.console.win.addEventListener("bottom-window-resize-end", this.handlePanelResizeEnd)
-        
-        this.buffer = ""
-        this.cursor = 0
-        this.history = []
-        this.historyIndex = -1
-        this.cwd = this.toDir(startPath) || ""
-        this.isWaitingForOutput = false
-        this.tabMatches = []
-        this.tabIndex = -1
-        this.tabPrefix = ""
 
-        this.customCommandDescriptions = {
-            fs: "Fullscreen mode",
-            "-fs": "Disable fullscreen",
-            "?": "All custom CodeMotion Terminal commands",
-            "cmexit": "Alias for exit command",
-            "clear": "Clear the terminal screen",
-            "cls": "Alias for clear"
-        }
-        this.customCommands = {
-            "fs": () => { 
-                this.console.fullscreen(); 
-                this.console.show(); 
-                this.term.writeln("CodeMotion: \x1b[1;30mFullscreen on\x1b[0m")
-            },
-            "-fs": () => { 
-                this.console.fullscreen(false); 
-                this.console.show(); 
-                this.term.writeln("CodeMotion: \x1b[1;30mFullscreen off\x1b[0m")
-            },
-            "?": () => {
-                Object.keys(this.customCommands).forEach(c => {
-                    this.term.writeln(`${c} \x1b[1;30m${this.customCommandDescriptions[c]}\x1b[0m`)
-                })
-            },
-            "cmexit": () => {
-                if(this.isWaitingForOutput) {
-                    this.isWaitingForOutput = false
-                    window.electron?.killProcess?.()
-                    this.term.writeln("\x1b[1;30mProcess terminated\x1b[0m")
-                    this.prompt()
-                } else {
-                    this.term.writeln("\x1b[1;30mNo active process to exit\x1b[0m")
-                }
-            },
-            "clear": () => {
-                this.term.write("\x1b[2J\x1b[3J\x1b[H")
-                this.term.write(`${this.cwd} $ `)
-                return true
-            },
-            "cls": () => {
-                return this.customCommands["clear"]()
-            }
-        }
-
-        this.prompt()
         this.registerEvents()
         this.setupIPC()
+        this.initPTY()
+
         this.console.onHide(() => this.dispose())
     }
 
@@ -106,6 +56,16 @@ export class Console {
         return p
     }
 
+    initPTY() {
+        if (window.electron?.initTerminal) {
+            window.electron.initTerminal({
+                cwd: this.cwd,
+                cols: this.term.cols || 80,
+                rows: this.term.rows || 24
+            })
+        }
+    }
+
     fit() {
         if (this.disposed) return
         if (this.isPanelResizing) return
@@ -115,14 +75,22 @@ export class Console {
             this.fitFrame = null
             if (this.disposed) return
             this.fitAddon?.fit()
+
+            if (window.electron?.resizeTerminal && this.term.cols && this.term.rows) {
+                window.electron.resizeTerminal({
+                    cols: this.term.cols,
+                    rows: this.term.rows
+                })
+            }
         })
     }
 
-    prompt() {
-        this.term.write(`\r\n${this.cwd} $ `)
-    }
-
     registerEvents() {
+        this.term.onData((data) => {
+            if (this.disposed) return
+            window.electron?.sendInput?.(data)
+        })
+
         this.term.attachCustomKeyEventHandler((e) => {
             if (e.ctrlKey && e.shiftKey && e.code === "KeyC") {
                 const selection = this.term.getSelection()
@@ -132,344 +100,33 @@ export class Console {
             if (e.ctrlKey && e.shiftKey && e.code === "KeyV") {
                 navigator.clipboard.readText().then(text => {
                     if (text) {
-                        const clean = text.replace(/[\r\n]+/g, " ")
-                        if (this.isWaitingForOutput) {
-                            this.buffer += clean
-                            this.term.write(clean)
-                        } else {
-                            this.insertAtCursor(clean)
-                        }
+                        window.electron?.sendInput?.(text)
                     }
-                }).catch(() => {})
+                })
                 return false
             }
             return true
         })
-        this.term.onData(data => this.handleInput(data))
-    }
-
-    handleInput(data) {
-        const code = data.charCodeAt(0)
-
-        if(code === 3) { 
-            if(this.isWaitingForOutput) {
-                this.term.write("^C\r\n")
-                window.electron?.killProcess?.()
-                this.isWaitingForOutput = false
-            } else if(this.buffer.length > 0) {
-                this.term.write("^C\r\n")
-                this.buffer = ""
-                this.cursor = 0
-            }
-            this.prompt()
-            return
-        }
-
-        if(code === 22) {
-            navigator.clipboard.readText().then(text => {
-                if (text) {
-                    const clean = text.replace(/[\r\n]+/g, " ")
-                    if (this.isWaitingForOutput) {
-                        this.buffer += clean
-                        this.term.write(clean)
-                    } else {
-                        this.insertAtCursor(clean)
-                    }
-                }
-            }).catch(() => {})
-            return
-        }
-
-        if(code === 13) {
-            this.term.write("\r\n")
-            this.tabMatches = []
-            this.tabIndex = -1
-            this.cursor = 0
-
-            if(this.isWaitingForOutput) {
-                const input = this.buffer + "\n"
-                console.log(`[Console] Sending input: "${input}"`)
-                window.electron?.sendInput?.(input)
-                this.buffer = ""
-                return
-            }
-            
-            const trimmedBuffer = this.buffer.trim()
-            
-            if(!trimmedBuffer) {
-                this.prompt()
-                return
-            }
-
-            const firstWord = trimmedBuffer.split(/\s+/)[0]
-            
-            if(this.customCommands[firstWord]) {
-                const handledPrompt = this.customCommands[firstWord]()
-                this.history.push(trimmedBuffer)
-                this.historyIndex = this.history.length
-                this.buffer = ""
-                if(handledPrompt !== true) this.prompt()
-            } else {
-                const cdMatch = trimmedBuffer.match(/^cd\s+(.*)$/i)
-                if (cdMatch) {
-                    const isWin = /^[a-zA-Z]:/.test(this.cwd) || this.cwd.includes("\\")
-                    const sep = isWin ? "\\" : "/"
-                    const root = isWin ? "C:\\" : "/"
-                    const rawTarget = cdMatch[1].trim()
-                    const isAbsolute = /^[a-zA-Z]:[\\/]/.test(rawTarget) || rawTarget.startsWith("/") || rawTarget.startsWith("\\")
-                    const target = rawTarget.replace(/[\\/]+$/, "")
-                    let newPath = this.cwd
-                    if (target === "..") {
-                        const parts = this.cwd.replace(/[\\/]+$/, "").split(/[\\/]/)
-                        parts.pop()
-                        newPath = parts.join(sep) || root
-                    } else if (isAbsolute) {
-                        newPath = target || root
-                    } else if (target === "" || target === ".") {
-                        newPath = this.cwd
-                    } else {
-                        newPath = this.cwd.replace(/[\\/]+$/, "") + sep + target
-                    }
-                    this.history.push(trimmedBuffer)
-                    this.historyIndex = this.history.length
-                    this.buffer = ""
-                    window.electron.readDirTree(newPath, { maxDepth: 0 }).then(res => {
-                        if (res) {
-                            this.cwd = newPath
-                        } else {
-                            this.term.writeln(`\x1b[31mcd: no such file or directory: ${target}\x1b[0m`)
-                        }
-                        this.prompt()
-                    }).catch(() => {
-                        this.term.writeln(`\x1b[31mcd: no such file or directory: ${target}\x1b[0m`)
-                        this.prompt()
-                    })
-                } else {
-                    this.history.push(trimmedBuffer)
-                    this.historyIndex = this.history.length
-                    this.buffer = ""
-                    this.isWaitingForOutput = true
-                    window.electron?.sendCommand?.({ cmd: trimmedBuffer, cwd: this.cwd })
-                }
-            }
-            return
-        }
-
-        if (this.isWaitingForOutput) {
-            if (code === 127) {
-                if (this.buffer.length > 0) {
-                    this.buffer = this.buffer.slice(0, -1)
-                    this.term.write("\b \b")
-                }
-                return
-            }
-            this.buffer += data
-            this.term.write(data)
-            window.electron?.sendInput?.(data)
-            return
-        }
-
-        if (code === 127) {
-            this.backspaceAtCursor()
-            return
-        }
-
-        if (data === '\x1B[A') {
-            if(this.historyIndex > 0) this.replaceBuffer(this.history[--this.historyIndex])
-            return
-        }
-        if (data === '\x1B[B') {
-            if(this.historyIndex < this.history.length - 1) this.replaceBuffer(this.history[++this.historyIndex])
-            else { this.historyIndex = this.history.length; this.replaceBuffer("") }
-            return
-        }
-        if (data === '\x1B[D') { this.moveLeft(); return }
-        if (data === '\x1B[C') { this.moveRight(); return }
-        if (data === '\x1B[H' || data === '\x1B[1~') { this.moveToStart(); return }
-        if (data === '\x1B[F' || data === '\x1B[4~') { this.moveToEnd(); return }
-        if (data === '\x1B[3~') { this.deleteAtCursor(); return }
-        if (code === 1) { this.moveToStart(); return }
-        if (code === 5) { this.moveToEnd(); return }
-
-        if (data === '\t') {
-            this.autocomplete()
-            return
-        }
-
-        if (code === 27 || code < 32) return
-
-        this.insertAtCursor(data)
-        this.tabMatches = []
-        this.tabIndex = -1
-    }
-
-    moveLeft() {
-        if (this.cursor > 0) {
-            this.cursor--
-            this.term.write('\x1b[D')
-        }
-    }
-
-    moveRight() {
-        if (this.cursor < this.buffer.length) {
-            this.cursor++
-            this.term.write('\x1b[C')
-        }
-    }
-
-    moveToStart() {
-        if (this.cursor > 0) {
-            this.term.write(`\x1b[${this.cursor}D`)
-            this.cursor = 0
-        }
-    }
-
-    moveToEnd() {
-        const diff = this.buffer.length - this.cursor
-        if (diff > 0) {
-            this.term.write(`\x1b[${diff}C`)
-            this.cursor = this.buffer.length
-        }
-    }
-
-    insertAtCursor(text) {
-        const after = this.buffer.slice(this.cursor)
-        this.buffer = this.buffer.slice(0, this.cursor) + text + after
-        this.cursor += text.length
-        this.term.write(text + after)
-        if (after.length) this.term.write(`\x1b[${after.length}D`)
-    }
-
-    backspaceAtCursor() {
-        if (this.cursor === 0) return
-        const after = this.buffer.slice(this.cursor)
-        this.buffer = this.buffer.slice(0, this.cursor - 1) + after
-        this.cursor--
-        this.term.write('\b' + after + ' ' + `\x1b[${after.length + 1}D`)
-    }
-
-    deleteAtCursor() {
-        if (this.cursor >= this.buffer.length) return
-        const after = this.buffer.slice(this.cursor + 1)
-        this.buffer = this.buffer.slice(0, this.cursor) + after
-        this.term.write(after + ' ' + `\x1b[${after.length + 1}D`)
-    }
-
-    replaceBuffer(str) {
-        this.moveToEnd()
-        while(this.buffer.length) {
-            this.term.write('\b \b')
-            this.buffer = this.buffer.slice(0, -1)
-        }
-        this.buffer = str
-        this.cursor = str.length
-        this.term.write(str)
-    }
-
-    async autocomplete() {
-        const commands = Object.keys(this.customCommands)
-        const parts = this.buffer.split(/\s+/)
-        const lastPart = parts[parts.length - 1] || ""
-
-        if (this.tabMatches.length > 0) {
-            this.tabIndex = (this.tabIndex + 1) % this.tabMatches.length
-            const completed = this.tabMatches[this.tabIndex]
-            if (parts.length <= 1 && commands.includes(completed)) {
-                this.replaceBuffer(completed + " ")
-            } else {
-                parts[parts.length - 1] = this.tabPrefix_path + completed
-                this.replaceBuffer(parts.join(" "))
-            }
-            return
-        }
-
-        let dir = this.cwd
-        let pathPrefix = ""
-        if (lastPart.includes("/") || lastPart.includes("\\")) {
-            const lastSlash = Math.max(lastPart.lastIndexOf("/"), lastPart.lastIndexOf("\\"))
-            pathPrefix = lastPart.substring(0, lastSlash + 1)
-            const relDir = lastPart.substring(0, lastSlash) || lastPart.substring(0, 1)
-            dir = (relDir.includes(":\\") || relDir.startsWith("/")) ? relDir : this.cwd + "\\" + relDir
-        }
-
-        try {
-            const res = await window.electron.readDirTree(dir, { maxDepth: 0 })
-            if (!res || !Array.isArray(res)) return
-
-            const entries = res.map(e => typeof e === "string" ? e : e.name || "")
-            const lower = lastPart.toLowerCase()
-            const fileMatches = entries.filter(e => e.toLowerCase().startsWith(lastPart.split(/[\\/]/).pop().toLowerCase()))
-
-            if (fileMatches.length === 0) return
-
-            this.tabMatches = fileMatches
-            this.tabIndex = 0
-            this.tabPrefix_path = pathPrefix
-
-            if (fileMatches.length === 1) {
-                parts[parts.length - 1] = pathPrefix + fileMatches[0]
-                this.replaceBuffer(parts.join(" "))
-            } else {
-                this.replaceBuffer(pathPrefix + fileMatches[0])
-            }
-        } catch (e) {}
-    }
-
-    parseCommand(cmd) {
-        const regex = /(?:[^\s"]+|"[^"]*")+/g
-        const args = []
-        let match
-        while((match = regex.exec(cmd)) !== null) {
-            let arg = match[0]
-            if(arg.startsWith('"') && arg.endsWith('"')) arg = arg.slice(1,-1)
-            args.push(arg)
-        }
-        return args
-    }
-
-    executeCommand(cmd) {
-        if (!cmd) return
-
-        const args = this.parseCommand(cmd)
-        const command = args.shift()
-
-        if (this.customCommands[command]) {
-            this.customCommands[command](...args)
-            return
-        }
-
-        if(window.electron?.sendCommand) {
-            window.electron.sendCommand({ cmd, cwd: this.cwd })
-        } else {
-            this.term.writeln(`Command not found: ${command}`)
-        }
     }
 
     setupIPC() {
-        if(window.electron && window.electron.onCommandResult) {
+        if (window.electron && window.electron.onCommandResult) {
             this.commandResultHandler = (result) => {
                 if (this.disposed) return
-
-                console.log('[Console] Received result:', result)
                 this.handleTerminalResult(result)
             }
 
             this.removeCommandResultHandler = window.electron.onCommandResult(this.commandResultHandler)
-        } else {
-            console.warn('[Console] onCommandResult not available')
         }
     }
 
     handleTerminalResult(result) {
+        if (!result) return
+
         let output = ""
         let type = "output"
 
-        if (!result) {
-            console.warn('[Console] Empty result')
-            return
-        }
-
-        if (result && typeof result === 'object') {
+        if (typeof result === 'object') {
             type = result.type || "output"
             output = result.data || result.output || result.message || ""
         } else if (typeof result === 'string') {
@@ -478,29 +135,17 @@ export class Console {
             output = JSON.stringify(result)
         }
 
-        console.log(`[Console] Type: "${type}", Output length: ${output.length}`)
-
         if (!output) return
 
-        switch(type) {
+        switch (type) {
             case "error":
-                this.term.write("\x1b[31m" + output + "\x1b[0m")
-                break
-            case "warning":
-                this.term.write("\x1b[38;5;208m" + output + "\x1b[0m")
+                this.term.write(output)
                 break
             case "exit":
                 this.term.write(output)
-                this.isWaitingForOutput = false
-                this.prompt()
-                return
+                break
             default:
                 this.term.write(output)
-        }
-
-        if(type === "exit") {
-            this.isWaitingForOutput = false
-            this.prompt()
         }
     }
 
@@ -508,7 +153,6 @@ export class Console {
         if (this.disposed) return
 
         this.disposed = true
-        this.isWaitingForOutput = false
         window.electron?.cleanupTerminal?.()
         this.resizeObserver?.disconnect()
         window.removeEventListener("resize", this.handleResize)

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+    "vcs": {
+        "enabled": true,
+        "clientKind": "git",
+        "useIgnoreFile": true
+    },
+    "files": {
+        "maxSize": 5242880,
+        "includes": [
+            "app/**/*",
+            "assets/js/**/*",
+            "assets/css/**/*",
+            "helpers/**/*",
+            "tests/**/*",
+            "html/**/*",
+            "languages/**/*",
+            "package.json",
+            "tsconfig*.json"
+        ]
+    },
+    "formatter": {
+        "enabled": true,
+        "indentStyle": "space",
+        "indentWidth": 4,
+        "lineWidth": 120
+    },
+    "assist": {
+        "actions": {
+            "source": {
+                "organizeImports": "off"
+            }
+        }
+    },
+    "linter": {
+        "enabled": false
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "double",
+            "semicolons": "asNeeded"
+        }
+    },
+    "overrides": [
+        {
+            "includes": ["assets/js/external/**", "codemirror/**", "ace/**", "dist/**", "build/**"],
+            "formatter": {
+                "enabled": false
+            }
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -2,12 +2,16 @@
     "name": "codemotion-app",
     "version": "0.0.9-alpha.dev",
     "description": "Web-focused, advanced open-source code editor (IDE) with native tools for web developers",
-    "author": "Yurba.Developers",
+    "author": {
+        "name": "Yurba Developers",
+        "email": "dev@yurba.one"
+    },
     "main": "app/dist/main.js",
     "scripts": {
         "build": "tsc && tsc -p tsconfig.esm.json",
         "test": "node --test tests/unit/*.test.mjs",
-        "cdbuild": "cd codemirror && npm i && npm run build",
+        "install": "cd codemirror && npm i",
+        "cdbuild": "cd codemirror && npm run build",
         "start": "npm run cdbuild && npm run build && electron .",
         "dist": "npm run cdbuild && npm run build && electron-builder",
         "dist-linux": "npm run cdbuild && npm run build && electron-builder --linux",
@@ -16,6 +20,7 @@
     "build": {
         "appId": "com.codemotion",
         "productName": "CodeMotion",
+        "artifactName": "codemotion-${version}.${ext}",
         "files": [
             "ace/**/*",
             "codemirror/**/*",
@@ -32,7 +37,11 @@
             }
         ],
         "win": {
-            "target": "nsis",
+            "target": [
+                "nsis",
+                "portable",
+                "zip"
+            ],
             "icon": "assets/media/builder-icons/app.ico"
         },
         "nsis": {
@@ -42,14 +51,25 @@
             "uninstallerIcon": "assets/media/builder-icons/app.ico"
         },
         "mac": {
-            "target": "dmg",
+            "target": [
+                "dmg",
+                "zip"
+            ],
             "icon": "assets/media/builder-icons/app.png"
         },
         "linux": {
             "category": "Development",
-            "target": "AppImage",
-            "syncDesktopName": true,
+            "target": [
+                "AppImage",
+                "deb",
+                "rpm",
+                "pacman",
+                "tar.gz"
+            ],
             "icon": "assets/media/builder-icons/app.png"
+        },
+        "deb": {
+            "maintainer": "Yurba Developers <dev@yurba.one>"
         }
     },
     "devDependencies": {
@@ -68,6 +88,7 @@
         "flashot": "^1.4.1",
         "ignore": "^7.0.6",
         "node-gyp": "^12.4.0",
+        "node-pty": "^1.1.0",
         "oxc-parser": "^0.140.0",
         "tar": "^7.5.21",
         "typescript": "^6.0.3",
@@ -78,6 +99,6 @@
         "electron@39.8.10": true
     },
     "overrides": {
-    	"yauzl": "^3.3.1"
+        "yauzl": "^3.3.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "scripts": {
         "build": "tsc && tsc -p tsconfig.esm.json",
         "test": "node --test tests/unit/*.test.mjs",
+        "lint": "biome check .",
+        "lint:fix": "biome check --write .",
+        "format": "biome format --write .",
         "install": "cd codemirror && npm i",
         "cdbuild": "cd codemirror && npm run build",
         "start": "npm run cdbuild && npm run build && electron .",
@@ -73,6 +76,7 @@
         }
     },
     "devDependencies": {
+        "@biomejs/biome": "^2.5.12",
         "@types/electron": "^1.4.38",
         "@types/node": "^25.9.1",
         "electron": "^39.8.10",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -4,7 +4,5 @@
         "module": "ES2022",
         "outDir": "app/dist-esm"
     },
-    "include": [
-        "app/main/textmate/compile.ts"
-    ]
+    "include": ["app/main/textmate/compile.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,19 +6,11 @@
         "rootDir": "app/main",
         "strict": true,
         "types": ["node", "electron"],
-        "lib": [
-            "ES2022"
-        ],
+        "lib": ["ES2022"],
         "esModuleInterop": true,
         "skipLibCheck": true,
         "allowJs": true
     },
     "include": ["app/main/**/*", "assets/js/editor/colorComments.js", "textmate/**/*"],
-    "exclude": [
-        "ace/**/*",
-        "assets/**/*",
-        "helpers/**/*",
-        "node_modules",
-        "dist"
-    ]
+    "exclude": ["ace/**/*", "assets/**/*", "helpers/**/*", "node_modules", "dist"]
 }


### PR DESCRIPTION
### Changes

1. **Interactive PTY Terminal (`node-pty`)**
   - Replaced pipe-based spawn execution with real pseudo-terminal (`node-pty`) sessions.
   - Full support for interactive shells and CLI tools (`bash`, `fish`, `zsh`, `python`, `htop`, `nano`, PowerShell, CMD).
   - Dynamic viewport resizing (`terminal-resize`) synchronizing `cols` and `rows` with `xterm.js`.

2. **Biome Formatter & Linter**
   - Added Biome configuration (`biome.json`) and package scripts (`lint`, `format`, `lint:fix`).
   - Added `.vscode/` settings for automatic `formatOnSave` on `Ctrl + S`.
   - Updated `README.md` Contributing Guidelines with linting & test instructions.

3. **Packaging & Build Improvements**
   - Configured Linux build targets: `deb`, `rpm`, `pacman` (`.pkg.tar.zst`), `AppImage`, and `tar.gz`.
   - Added Windows portable & zip targets and macOS DMG/zip.
   - Updated `.github/workflows/build.yml` for unified artifact bundling.
   - Added `bun.lock` to `.gitignore`.